### PR TITLE
Add disposal issue configuration page and link

### DIFF
--- a/Pharmacy-Configuration-and-Privileges.md
+++ b/Pharmacy-Configuration-and-Privileges.md
@@ -48,7 +48,7 @@ This section describes the configuration options and privileges required for man
 
 ## Disposal
 
-### Issue
+### [Issue](Pharmacy-Disposal-Issue-Configuration)
 
 **Page:** `/pharmacy/pharmacy_issue.xhtml`
 **Navigation:** Menu ▸ Pharmacy ▸ Disposal ▸ Issue

--- a/Pharmacy-Disposal-Issue-Configuration.md
+++ b/Pharmacy-Disposal-Issue-Configuration.md
@@ -1,0 +1,63 @@
+# Disposal Issue Configuration
+
+## Configuration Options
+
+### Main Page
+
+* Consumption – Show Rate and Value
+
+### History Section – Display Blocks
+
+* Stocks Block
+* Sale Block
+* BHT Issue Block
+* Whole Sale Block
+* Transfer Issue Block
+* GRN Block
+* GRN Return Block
+* Pending GRN Block
+* Purchase Orders Block
+
+### History Section – Display Tabview
+
+* Tabview toggle
+* Stocks Tab
+* Sale Tab
+* Sale Bill Item Tab
+* Whole Sale Tab
+* BHT Issue Tab
+* Transfer Issue Tab
+* Transfer Receive Tab
+* Department Issue Tab
+* GRN Tab
+* Pending GRN Tab
+* GRN Return Tab
+* Purchase Orders Tab
+* Pending PO Tab
+* Direct Purchase Tab
+* Pack Sizes Tab
+
+### Issue Receipt Options
+
+* Receipt CSS
+* Receipt Header
+* Receipt Footer
+* Display Retail Rate
+* Display Purchase Rate
+* Display Cost Rate
+* Display Issue Value
+* Display Retail Value
+* Display Purchase Value
+* Display Cost Value
+
+## Privileges
+
+* ConsumptionViewRates – required to view rate/value information when enabled.
+* ChangeReceiptPrintingPaperTypes – required to change paper type before printing receipts.
+
+No additional privileges are enforced inside embedded components.
+
+[Back to Pharmacy Configuration and Privileges](Pharmacy-Configuration-and-Privileges)
+[Back to Pharmacy Administration](Pharmacy-Administration)
+[Back to Pharmacy](Pharmacy)
+[Back to User Manual](User-Manual)


### PR DESCRIPTION
## Summary
- document disposal issue configuration options, history sections, and receipt settings
- link to new disposal issue configuration page from pharmacy configuration overview

## Testing
- `markdownlint --disable MD013 MD034 MD012 -- Pharmacy-Disposal-Issue-Configuration.md Pharmacy-Configuration-and-Privileges.md`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e5b43d8c832faf29009798b4be48