### PR TITLE
Link wiki automation guide and add back link

### DIFF
--- a/Developer-Manual.md
+++ b/Developer-Manual.md
@@ -18,6 +18,7 @@
 * [Controllers](https://github.com/hmislk/hmis/wiki/Controllers)
 * [Training-Schedule](https://github.com/hmislk/hmis/wiki/26%E2%80%90Week-Training-Schedule-for-Software-Trainee-Engineers)
 * [How to create a printing page](https://github.com/hmislk/hmis/wiki/How-to-Create-a-Printing-Page)
+* [Wiki Automation Guide](https://github.com/hmislk/hmis/wiki/Wiki-Automation-Guide)
 * [Displaying Configuration Options for Developers at Page Bottom](https://github.com/hmislk/hmis/wiki/Displaying-Configuration-Options-for-Developers-at-Page-Bottom)
 
 

--- a/Wiki-Automation-Guide.md
+++ b/Wiki-Automation-Guide.md
@@ -221,3 +221,4 @@ scripts/sync-wiki.bat  # Windows
 - [System Administration Guide](System-Administration.md)
 
 **Last Updated:** Auto-generated on each sync
+[Back](https://github.com/hmislk/hmis/wiki/Developer-Manual)


### PR DESCRIPTION
## Summary
- Link the Wiki Automation Guide from the developer manual
- Add a back link to the Wiki Automation Guide pointing to the developer manual

## Testing
- `python - <<'PY'
import os, subprocess
md_files=[]
for root, dirs, files in os.walk('.'):
    for f in files:
        if f.endswith('.md'):
            md_files.append(os.path.join(root, f))
orphan=[]
for path in md_files:
    base=os.path.splitext(os.path.basename(path))[0]
    cmd=['rg','-l','--fixed-strings','-g','*.md',base,'.']
    res=subprocess.run(cmd, capture_output=True, text=True)
    files=[x for x in res.stdout.strip().split('\n') if x]
    files=[x for x in files if os.path.normpath(x)!=os.path.normpath(path)]
    if not files:
        orphan.append(path)
print('orphan found for wiki automation?', any(p.endswith('Wiki-Automation-Guide.md') for p in orphan))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aa0f328768832fb0ddecfd1045c5ad