### PR TITLE
Add API documentation links

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,3 +7,4 @@ API Key Based Security - Key, Value - can have expiary
 OAuth 2.0
 KeyCloack
 
+[Back](https://github.com/hmislk/hmis/wiki/Developer-Manual)

--- a/Developer-Manual.md
+++ b/Developer-Manual.md
@@ -1,6 +1,7 @@
 * [Techstack](https://github.com/hmislk/hmis/wiki/Tech-Stack)
 * [Installation Manual](https://github.com/hmislk/hmis/wiki/Installation-Manual)
 * [Maintenance Manual](https://github.com/hmislk/hmis/wiki/Maintenance-Manual)
+* [API](https://github.com/hmislk/hmis/wiki/API)
 * [Code Conventions](https://github.com/hmislk/hmis/wiki/Code-Conventions)
 * [Starters Guide](https://github.com/hmislk/hmis/wiki/Starters-Guide)
 * [Developer Guidelines](https://github.com/hmislk/hmis/wiki/Developer-Guidelines)

--- a/User-Manual.md
+++ b/User-Manual.md
@@ -19,6 +19,7 @@ User Manual
 * [Preferences](https://github.com/hmislk/hmis/wiki/Managing-Preferences)
 * [System Administration](https://github.com/hmislk/hmis/wiki/System-Administration)
 * [Patient & Doctor Portals](https://github.com/hmislk/hmis/wiki/Patient-and-Doctor-Portals)
+* [API](https://github.com/hmislk/hmis/wiki/API)
 
 
 


### PR DESCRIPTION
## Summary
- Link API guide back to Developer Manual
- Add API to Developer Manual and User Manual indices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0371b39c832f8a732ea5b213895b