### PR TITLE
Add Developer Manual navigation link and footer

### DIFF
--- a/Developer-Manual.md
+++ b/Developer-Manual.md
@@ -20,5 +20,4 @@
 * [How to create a printing page](https://github.com/hmislk/hmis/wiki/How-to-Create-a-Printing-Page)
 * [Displaying Configuration Options for Developers at Page Bottom](https://github.com/hmislk/hmis/wiki/Displaying-Configuration-Options-for-Developers-at-Page-Bottom)
 
-
 [Back](https://github.com/hmislk/hmis/wiki)

--- a/User-Manual.md
+++ b/User-Manual.md
@@ -19,7 +19,6 @@ User Manual
 * [Preferences](https://github.com/hmislk/hmis/wiki/Managing-Preferences)
 * [System Administration](https://github.com/hmislk/hmis/wiki/System-Administration)
 * [Patient & Doctor Portals](https://github.com/hmislk/hmis/wiki/Patient-and-Doctor-Portals)
-
-
+* [Developer Manual](https://github.com/hmislk/hmis/wiki/Developer-Manual)
 
 [Back](https://github.com/hmislk/hmis/wiki)


### PR DESCRIPTION
## Summary
- Ensure Developer Manual page includes a back link to the wiki home.
- Add Developer Manual to the User Manual index for easier navigation.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0361abb8832fbcb6979ff6bf48aa